### PR TITLE
Upgrade to handlebars.java 4.0.6 + bump version to 0.2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    compile 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.2.12'
+    compile 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.2.13'
 }
 ```
 ## Helpers
@@ -27,10 +27,10 @@ Spring Boot Starter Handlebars will automatically register handlebars helpers ba
 Add any handlebars helper to dependencies and you can start using it.
 ```gradle
 dependencies {
-    compile 'com.github.jknack:handlebars-helpers:4.0.4',
-            'com.github.jknack:handlebars-jackson2:4.0.4',
-            'com.github.jknack:handlebars-humanize:4.0.4',
-            'com.github.jknack:handlebars-markdown:4.0.4'
+    compile 'com.github.jknack:handlebars-helpers:4.0.6',
+            'com.github.jknack:handlebars-jackson2:4.0.6',
+            'com.github.jknack:handlebars-humanize:4.0.6',
+            'com.github.jknack:handlebars-markdown:4.0.6'
 }
 ```
 NOTE: Jackson2Helper and MarkdownHelper will register with name `json` and `md` respectively.

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ project.version = scmVersion.version
 ext {
     jodaVersion = '2.8'
     spockVersion = '1.0-groovy-2.4'
-    handlebarsVersion = '4.0.4'
+    handlebarsVersion = '4.0.6'
     springBootVersion = '1.3.2.RELEASE'
 }
 


### PR DESCRIPTION
Since we run into issues with https://github.com/allegro/handlebars-spring-boot-starter/issues/21 we would like to upgrade to 0.2.12. But since 0.2.12 depends on the revoked 4.0.5 of handlebars.java, it's necessary to get an updated version of this handlebars spring boot starter with 4.0.6 shipped.

This PR includes:

- upgrade to 4.0.6 of handlebars.java
- update the examples to version number 0.2.13 and expecting that this will be released as 0.2.13